### PR TITLE
ZBM Gearscript Update + Arsenal Export

### DIFF
--- a/addons/arsenalExport/functions/fnc_arsenalOpened.sqf
+++ b/addons/arsenalExport/functions/fnc_arsenalOpened.sqf
@@ -11,14 +11,14 @@ if ((count (call BIS_fnc_listPlayers)) > 1) exitWith {INFO_1("hiding export in m
 
 
 private _y = 0;
-private _ctrlsToUpdate = [];
+_ctrlsToUpdate = [];
 
 private _height = (((safezoneW / safezoneH) min 1.2) / 1.2) / 25;
 private _xPos = safezoneX + safezoneW - 10 * _height;
 if (_shiftLeft) then {
     _xPos = _xPos - 93 * GRID_W;
 };
-private _yPos = (safezoneY + 1.5 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)) + 16 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25);
+private _yPos = (safezoneY + -2 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25)) + 16 * ((((safezoneW / safezoneH) min 1.2) / 1.2) / 25);
 
 private _fnc_createButton = {
     params ["_text", "_fncString", "_varsArray"];
@@ -38,15 +38,57 @@ private _fnc_createButton = {
     _y = _y + 1;
 };
 
+/*
+_fnc_AdvDefines = {
+
+GVAR(AdvDefines) = true;
+};
+
+_y = _y + 1;
+private _rscButton = _display ctrlCreate ["RscButton", -1];
+_rscButton ctrlSetText "Adv. Defines";
+_rscButton ctrlSetEventHandler ["ButtonClick", 'call _fnc_AdvDefines'];
+_rscButton ctrlSetPosition [_xPos + (1 * _height), _yPos + _height * (_y + 0.25), 8 * _height, _height];
+_rscButton ctrlCommit 0.25;
+_y = _y + 1;
+private _rscButton = _display ctrlCreate ["RscButton", -1];
+_rscButton ctrlSetText "Export";
+_rscButton ctrlSetEventHandler ["ButtonClick", 'call FUNC(export)'];
+_rscButton ctrlSetPosition [_xPos + (1 * _height), _yPos + _height * (_y + 0.25), 8 * _height, _height];
+_rscButton ctrlCommit 0.25;
+_y = _y + 1.25;
+*/
+
+private _rscButton = _display ctrlCreate ["RscButton", -1];
+_rscButton ctrlSetText "Reset Defines";
+_rscButton ctrlAddEventHandler ["ButtonClick", format ['[ctrlParent (_this select 0), "%1"] call FUNC(buttonClick)', "reset"]];
+_rscButton ctrlSetPosition [_xPos + (1 * _height), _yPos + _height * (_y + 0.25), 8 * _height, _height];
+_rscButton ctrlCommit 0.25;
+_y = _y + 1.5;
+
 ["Set Uniform", "uniform", [QGVAR(loadout_uniform), QGVAR(loadout_vest), QGVAR(loadout_backpack), QGVAR(loadout_headgear)]] call _fnc_createButton;
 ["Set Rifle", "rifle", [QGVAR(loadout_rifle), QGVAR(loadout_rifleMags), QGVAR(loadout_rifleAttachments)]] call _fnc_createButton;
 ["Set GL Rifle", "glrifle", [QGVAR(loadout_glrifle), QGVAR(loadout_glRifleMags)]] call _fnc_createButton;
 ["Set Carbine", "carbine", [QGVAR(loadout_carbine), QGVAR(loadout_carbineMags)]] call _fnc_createButton;
-["Set AR", "ar", [QGVAR(loadout_ar), QGVAR(loadout_arMags)]] call _fnc_createButton;
+["Set AR", "ar", [QGVAR(loadout_ar), QGVAR(loadout_arMags), QGVAR(loadout_arAttachments)]] call _fnc_createButton;
 ["Set MMG", "mmg", [QGVAR(loadout_mmg), QGVAR(loadout_mmgMags)]] call _fnc_createButton;
 ["Set AT", "at", [QGVAR(loadout_at), QGVAR(loadout_atMags)]] call _fnc_createButton;
 ["Set MAT", "mat", [QGVAR(loadout_mat), QGVAR(loadout_matMags)]] call _fnc_createButton;
-
+["Set GOG", "gog", [QGVAR(loadout_goggles)]] call _fnc_createButton;
+/*
+["Set HMG", "hmg", [QGVAR(loadout_hmg), QGVAR(loadout_hmgMags)]] call _fnc_createButton;
+["Set HAT", "hat", [QGVAR(loadout_hat), QGVAR(loadout_hatMags)]] call _fnc_createButton;
+["Set SAM", "sam", [QGVAR(loadout_sam), QGVAR(loadout_samMags)]] call _fnc_createButton;
+["Set Sniper", "sniper", [QGVAR(loadout_sniper), QGVAR(loadout_sniperMags)]] call _fnc_createButton;
+["Set Spotter", "spotter", [QGVAR(loadout_spotter), QGVAR(loadout_spotterMags)]] call _fnc_createButton;
+["Set SMG", "smg", [QGVAR(loadout_smg), QGVAR(loadout_smgMags)]] call _fnc_createButton;
+["Set Pistol", "pistol", [QGVAR(loadout_pistol), QGVAR(loadout_pistolMags)]] call _fnc_createButton;
+["Set MTR T", "mtrt", [QGVAR(loadout_mtrt)]] call _fnc_createButton;
+["Set MTR B", "mtrb", [QGVAR(loadout_mtrb)]] call _fnc_createButton;
+["Set Crew H", "crewh", [QGVAR(loadout_crewh)]] call _fnc_createButton;
+["Set Pilot", "pilot", [QGVAR(loadout_puniform), QGVAR(loadout_pvest), QGVAR(loadout_pbackpack), QGVAR(loadout_pheadgear)]] call _fnc_createButton;
+["Set NODS", "nods", [QGVAR(loadout_nods)]] call _fnc_createButton;
+*/
 private _rscButton = _display ctrlCreate ["RscButton", -1];
 _rscButton ctrlSetText "Export";
 _rscButton ctrlSetEventHandler ["ButtonClick", 'call FUNC(export)'];

--- a/addons/arsenalExport/functions/fnc_buttonClick.sqf
+++ b/addons/arsenalExport/functions/fnc_buttonClick.sqf
@@ -5,55 +5,398 @@ TRACE_2("canAttach",_display,_fncString);
 
 private _unit = missionNamespace getVariable ["ace_arsenal_center", player]; /// supports ace arsanal in 3den
 
-switch (toLower _fncString) do {
-case ("init"): {systemChat "Init";};
-case ("uniform"): {
+switch (toLower _fncString)
+  do {
+    case ("init"): {systemChat "Init";};
+    case ("uniform"): {
+      if (typeName GVAR(loadout_uniform) == "STRING" && {
+          GVAR(loadout_uniform) == "NotSet"
+        }) then {
         GVAR(loadout_uniform) = uniform _unit;
+      } else {
+        if (typeName GVAR(loadout_uniform) == "STRING") then {
+          if (GVAR(loadout_uniform) == "") then {
+            GVAR(loadout_uniform) = uniform _unit;
+          }
+          else {
+            private _UniformTMP = [uniform _unit];
+            _UniformTMP pushBackUnique GVAR(loadout_uniform);
+            GVAR(loadout_uniform) = _UniformTMP;
+          };
+        } else {
+          private _UniformTMP = uniform _unit;
+          if (_UniformTMP != "") then {
+            GVAR(loadout_uniform) pushBackUnique _UniformTMP
+          };
+        };
+      };
+      if (typeName GVAR(loadout_vest) == "STRING" && {
+          GVAR(loadout_vest) == "NotSet"
+        }) then {
         GVAR(loadout_vest) = vest _unit;
+        private _VestTMP = [vest _unit];
+      } else {
+        if (typeName GVAR(loadout_vest) == "STRING") then {
+          if (GVAR(loadout_vest) == "") then {
+            GVAR(loadout_vest) = vest _unit;
+          }
+          else {
+            private _VestTMP = [vest _unit];
+            _VestTMP pushBackUnique GVAR(loadout_vest);
+            GVAR(loadout_vest) = _VestTMP;
+          };
+        } else {
+          private _VestTMP = vest _unit;
+          if (_VestTMP != "") then {
+            GVAR(loadout_vest) pushBackUnique _VestTMP
+          };
+        };
+      };
+      if (typeName GVAR(loadout_backpack) == "STRING" && {
+          GVAR(loadout_backpack) == "NotSet"
+        }) then {
         GVAR(loadout_backpack) = backpack _unit;
+      } else {
+        if (typeName GVAR(loadout_backpack) == "STRING") then {
+          if (GVAR(loadout_backpack) == "") then {
+            GVAR(loadout_backpack) = backpack _unit;
+          }
+          else {
+            private _BackpackTMP = [backpack _unit];
+            _BackpackTMP pushBackUnique GVAR(loadout_backpack);
+            GVAR(loadout_backpack) = _BackpackTMP;
+          };
+        } else {
+          private _BackpackTMP = backpack _unit;
+          if (_BackpackTMP != "") then {
+            GVAR(loadout_backpack) pushBackUnique _BackpackTMP
+          };
+        };
+      };
+      if (typeName GVAR(loadout_headgear) == "STRING" && {
+          GVAR(loadout_headgear) == "NotSet"
+        }) then {
         GVAR(loadout_headgear) = headgear _unit;
-        systemChat format ["[Set %1]: %2 %3 %4 %5", _fncString, GVAR(loadout_uniform), GVAR(loadout_vest), GVAR(loadout_backpack), GVAR(loadout_headgear)];
+      } else {
+        if (typeName GVAR(loadout_headgear) == "STRING") then {
+          if (GVAR(loadout_headgear) == "") then {
+            GVAR(loadout_headgear) = headgear _unit;
+          }
+          else {
+            private _HeadgearTMP = [headgear _unit];
+            _HeadgearTMP pushBackUnique GVAR(loadout_headgear);
+            GVAR(loadout_headgear) = _HeadgearTMP;
+          };
+        } else {
+          private _HeadgearTMP = headgear _unit;
+          if (_HeadgearTMP != "") then {
+            GVAR(loadout_headgear) pushBackUnique _HeadgearTMP
+          };
+        };
+      };
+      systemChat format["[Set %1]: %2 %3 %4 %5", _fncString, GVAR(loadout_uniform), GVAR(loadout_vest), GVAR(loadout_backpack), GVAR(loadout_headgear)];
     };
-case ("rifle"): {
-        GVAR(loadout_rifle) = primaryWeapon _unit;
-        GVAR(loadout_rifleMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_rifle)] call CBA_fnc_compatibleMagazines);
-        GVAR(loadout_rifleAttachments) = primaryWeaponItems _unit;
-        systemChat format ["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_rifle), GVAR(loadout_rifleMags), GVAR(loadout_rifleAttachments)];
+    case ("rifle"): {
+      GVAR(loadout_rifle) = primaryWeapon _unit;
+      GVAR(loadout_rifleMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_rifle)] call CBA_fnc_compatibleMagazines);
+      GVAR(loadout_rifleAttachments) = primaryWeaponItems _unit;
+      systemChat format["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_rifle), GVAR(loadout_rifleMags), GVAR(loadout_rifleAttachments)];
     };
-case ("glrifle"): {
-        GVAR(loadout_glrifle) = primaryWeapon _unit;
-        GVAR(loadout_glRifleMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_glrifle)] call CBA_fnc_compatibleMagazines);
-        systemChat format ["[Set %1]: %2 %3", _fncString, GVAR(loadout_glrifle), GVAR(loadout_glRifleMags)];
+    case ("glrifle"): {
+      GVAR(loadout_glrifle) = primaryWeapon _unit;
+      GVAR(loadout_glRifleMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_glrifle)] call CBA_fnc_compatibleMagazines);
+      systemChat format["[Set %1]: %2 %3", _fncString, GVAR(loadout_glrifle), GVAR(loadout_glRifleMags)];
     };
-case ("carbine"): {
-        GVAR(loadout_carbine) = primaryWeapon _unit;
-        GVAR(loadout_carbineMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_carbine)] call CBA_fnc_compatibleMagazines);
-        systemChat format ["[Set %1]: %2 %3", _fncString, GVAR(loadout_carbine), GVAR(loadout_carbineMags)];
+    case ("carbine"): {
+      GVAR(loadout_carbine) = primaryWeapon _unit;
+      GVAR(loadout_carbineMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_carbine)] call CBA_fnc_compatibleMagazines);
+      systemChat format["[Set %1]: %2 %3", _fncString, GVAR(loadout_carbine), GVAR(loadout_carbineMags)];
     };
-case ("ar"): {
-        GVAR(loadout_ar) = primaryWeapon _unit;
-        GVAR(loadout_arMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_ar)] call CBA_fnc_compatibleMagazines);
-        systemChat format ["[Set %1]: %2 %3", _fncString, GVAR(loadout_ar), GVAR(loadout_arMags)];
+    case ("ar"): {
+      GVAR(loadout_ar) = primaryWeapon _unit;
+      GVAR(loadout_arMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_ar)] call CBA_fnc_compatibleMagazines);
+      GVAR(loadout_arAttachments) = primaryWeaponItems _unit;
+      systemChat format["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_ar), GVAR(loadout_arMags), GVAR(loadout_arAttachments)];
     };
-case ("mmg"): {
-        GVAR(loadout_mmg) = primaryWeapon _unit;
-        GVAR(loadout_mmgMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_mmg)] call CBA_fnc_compatibleMagazines);
-        systemChat format ["[Set %1]: %2 %3", _fncString, GVAR(loadout_mmg), GVAR(loadout_mmgMags)];
+    case ("mmg"): {
+      GVAR(loadout_mmg) = primaryWeapon _unit;
+      GVAR(loadout_mmgMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_mmg)] call CBA_fnc_compatibleMagazines);
+      GVAR(loadout_mmgAttachments) = primaryWeaponItems _unit;
+      systemChat format["[Set %1]: %2 %3", _fncString, GVAR(loadout_mmg), GVAR(loadout_mmgMags), GVAR(loadout_mmgAttachments)];
     };
-case ("at"): {
-        GVAR(loadout_at) = secondaryWeapon _unit;
-        GVAR(loadout_atMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_at)] call CBA_fnc_compatibleMagazines);
-        systemChat format ["[Set %1]: %2 %3", _fncString, GVAR(loadout_at), GVAR(loadout_atMags)];
+    case ("at"): {
+      GVAR(loadout_at) = secondaryWeapon _unit;
+      GVAR(loadout_atMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_at)] call CBA_fnc_compatibleMagazines);
+      systemChat format["[Set %1]: %2 %3", _fncString, GVAR(loadout_at), GVAR(loadout_atMags)];
     };
-case ("mat"): {
-        GVAR(loadout_mat) = secondaryWeapon _unit;
-        GVAR(loadout_matMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect ([GVAR(loadout_mat)] call CBA_fnc_compatibleMagazines);
-        GVAR(loadout_matAttachments) = secondaryWeaponItems _unit;
-        systemChat format ["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_mat), GVAR(loadout_matMags), GVAR(loadout_matAttachments)];
+    case ("mat"): {
+      GVAR(loadout_mat) = secondaryWeapon _unit;
+      GVAR(loadout_matMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_mat)] call CBA_fnc_compatibleMagazines);
+      GVAR(loadout_matAttachments) = secondaryWeaponItems _unit;
+      systemChat format["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_mat), GVAR(loadout_matMags), GVAR(loadout_matAttachments)];
     };
-    default {ERROR_1("bad fnc [%1]",_fncString);};
-};
-
+    case ("hmg"): {
+      GVAR(loadout_hmg) = secondaryWeapon _unit;
+      GVAR(loadout_hmgMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_hmg)] call CBA_fnc_compatibleMagazines);
+      GVAR(loadout_hmgAttachments) = secondaryWeaponItems _unit;
+	  switch (GVAR(loadout_hmg)) do {
+	  case "CUP_KORD_carry";
+	  case "ace_compat_rhs_afrf3_kord_carry": {
+      GVAR(loadout_hmgtrilo) = "ace_csw_kordCarryTripodLow";
+      GVAR(loadout_hmgtrihi) = "ace_csw_kordCarryTripod";
+	  };
+	  case "CUP_m2_carry";
+	  case "ace_csw_staticM2ShieldCarry";
+	  case "ace_csw_staticHMGCarry";
+	  case "ace_compat_rhs_usf3_m2_carry": {
+      GVAR(loadout_hmgtrilo) = "ace_csw_m3CarryTripodLow";
+      GVAR(loadout_hmgtrihi) = "ace_csw_m3CarryTripod";
+	  };
+	  default {
+      GVAR(loadout_hmgtrilo) = "";
+      GVAR(loadout_hmgtrihi) = "";
+	  };
+	  };
+      systemChat format["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_hmg), GVAR(loadout_hmgMags), GVAR(loadout_hmgAttachments)];
+    };
+    case ("hat"): {
+      GVAR(loadout_hat) = secondaryWeapon _unit;
+      GVAR(loadout_hatMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_hat)] call CBA_fnc_compatibleMagazines);
+      GVAR(loadout_hatAttachments) = secondaryWeaponItems _unit;
+      GVAR(loadout_hattrilo) = "";
+      GVAR(loadout_hattrihi) = "";
+      systemChat format["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_hat), GVAR(loadout_hatMags), GVAR(loadout_hatAttachments)];
+    };
+    case ("sam"): {
+      GVAR(loadout_sam) = secondaryWeapon _unit;
+      GVAR(loadout_samMags) = ((secondaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_sam)] call CBA_fnc_compatibleMagazines);
+      GVAR(loadout_samAttachments) = secondaryWeaponItems _unit;
+      systemChat format["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_sam), GVAR(loadout_samMags), GVAR(loadout_samAttachments)];
+    };
+    case ("sniper"): {
+      GVAR(loadout_sniper) = primaryWeapon _unit;
+      GVAR(loadout_sniperMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_sniper)] call CBA_fnc_compatibleMagazines);
+      GVAR(loadout_sniperAttachments) = primaryWeaponItems _unit;
+      systemChat format["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_sniper), GVAR(loadout_sniperMags), GVAR(loadout_sniperAttachments)];
+    };
+    case ("spotter"): {
+      GVAR(loadout_spotter) = primaryWeapon _unit;
+      GVAR(loadout_spotterMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_spotter)] call CBA_fnc_compatibleMagazines);
+      GVAR(loadout_spotterAttachments) = primaryWeaponItems _unit;
+      systemChat format["[Set %1]: %2 %3 %4", _fncString, GVAR(loadout_spotter), GVAR(loadout_spotterMags), GVAR(loadout_spotterAttachments)];
+    };
+    case ("smg"): {
+      GVAR(loadout_smg) = primaryWeapon _unit;
+      GVAR(loadout_smgMags) = ((primaryWeaponMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_smg)] call CBA_fnc_compatibleMagazines);
+      systemChat format["[Set %1]: %2 %3", _fncString, GVAR(loadout_smg), GVAR(loadout_smgMags)];
+    };
+    case ("pistol"): {
+      GVAR(loadout_pistol) = handgunWeapon _unit;
+      GVAR(loadout_pistolMags) = ((handgunMagazine _unit) + (magazines _unit)) arrayIntersect([GVAR(loadout_pistol)] call CBA_fnc_compatibleMagazines);
+      systemChat format["[Set %1]: %2 %3", _fncString, GVAR(loadout_pistol), GVAR(loadout_pistolMags)];
+    };
+    case ("mtrt"): {
+      GVAR(loadout_mtrt) = backpack _unit;
+      systemChat format["[Set %1]: %2", _fncString, GVAR(loadout_mtrt)];
+    };
+    case ("mtrb"): {
+      GVAR(loadout_mtrb) = backpack _unit;
+      systemChat format["[Set %1]: %2", _fncString, GVAR(loadout_mtrb)];
+    };
+    case ("crewh"): {
+      if (typeName GVAR(loadout_crewh) == "STRING" && {
+          GVAR(loadout_crewh) == "NotSet"
+        }) then {
+        GVAR(loadout_crewh) = headgear _unit;
+      } else {
+        if (typeName GVAR(loadout_crewh) == "STRING") then {
+          if (GVAR(loadout_crewh) == "") then {
+            GVAR(loadout_crewh) = headgear _unit;
+          }
+          else {
+            private _HeadgearTMP = [headgear _unit];
+            _HeadgearTMP pushBackUnique GVAR(loadout_crewh);
+            GVAR(loadout_crewh) = _HeadgearTMP;
+          };
+        } else {
+          private _HeadgearTMP = headgear _unit;
+          if (_HeadgearTMP != "") then {
+            GVAR(loadout_crewh) pushBackUnique _HeadgearTMP
+          };
+        };
+      };
+      systemChat format["[Set %1]: %2", _fncString, GVAR(loadout_crewh)];
+    };
+    case ("pilot"): {
+      if (typeName GVAR(loadout_puniform) == "STRING" && {
+          GVAR(loadout_puniform) == "NotSet"
+        }) then {
+        GVAR(loadout_puniform) = uniform _unit;
+      } else {
+        if (typeName GVAR(loadout_puniform) == "STRING") then {
+          if (GVAR(loadout_puniform) == "") then {
+            GVAR(loadout_puniform) = uniform _unit;
+          }
+          else {
+            private _UniformTMP = [uniform _unit];
+            _UniformTMP pushBackUnique GVAR(loadout_puniform);
+            GVAR(loadout_puniform) = _UniformTMP;
+          };
+        } else {
+          private _UniformTMP = uniform _unit;
+          if (_UniformTMP != "") then {
+            GVAR(loadout_puniform) pushBackUnique _UniformTMP
+          };
+        };
+      };
+      if (typeName GVAR(loadout_pvest) == "STRING" && {
+          GVAR(loadout_pvest) == "NotSet"
+        }) then {
+        GVAR(loadout_pvest) = vest _unit;
+        private _VestTMP = [vest _unit];
+      } else {
+        if (typeName GVAR(loadout_pvest) == "STRING") then {
+          if (GVAR(loadout_pvest) == "") then {
+            GVAR(loadout_pvest) = vest _unit;
+          }
+          else {
+            private _VestTMP = [vest _unit];
+            _VestTMP pushBackUnique GVAR(loadout_pvest);
+            GVAR(loadout_pvest) = _VestTMP;
+          };
+        } else {
+          private _VestTMP = vest _unit;
+          if (_VestTMP != "") then {
+            GVAR(loadout_pvest) pushBackUnique _VestTMP
+          };
+        };
+      };
+      if (typeName GVAR(loadout_pbackpack) == "STRING" && {
+          GVAR(loadout_pbackpack) == "NotSet"
+        }) then {
+        GVAR(loadout_pbackpack) = backpack _unit;
+      } else {
+        if (typeName GVAR(loadout_pbackpack) == "STRING") then {
+          if (GVAR(loadout_pbackpack) == "") then {
+            GVAR(loadout_pbackpack) = backpack _unit;
+          }
+          else {
+            private _BackpackTMP = [backpack _unit];
+            _BackpackTMP pushBackUnique GVAR(loadout_pbackpack);
+            GVAR(loadout_pbackpack) = _BackpackTMP;
+          };
+        } else {
+          private _BackpackTMP = backpack _unit;
+          if (_BackpackTMP != "") then {
+            GVAR(loadout_pbackpack) pushBackUnique _BackpackTMP
+          };
+        };
+      };
+      if (typeName GVAR(loadout_pheadgear) == "STRING" && {
+          GVAR(loadout_pheadgear) == "NotSet"
+        }) then {
+        GVAR(loadout_pheadgear) = headgear _unit;
+      } else {
+        if (typeName GVAR(loadout_pheadgear) == "STRING") then {
+          if (GVAR(loadout_pheadgear) == "") then {
+            GVAR(loadout_pheadgear) = headgear _unit;
+          }
+          else {
+            private _HeadgearTMP = [headgear _unit];
+            _HeadgearTMP pushBackUnique GVAR(loadout_pheadgear);
+            GVAR(loadout_pheadgear) = _HeadgearTMP;
+          };
+        } else {
+          private _HeadgearTMP = headgear _unit;
+          if (_HeadgearTMP != "") then {
+            GVAR(loadout_pheadgear) pushBackUnique _HeadgearTMP
+          };
+        };
+      };
+      systemChat format["[Set %1]: %2 %3 %4 %5", _fncString, GVAR(loadout_puniform), GVAR(loadout_pvest), GVAR(loadout_pbackpack), GVAR(loadout_pheadgear)];
+    };
+    case ("gog"): {
+      if (typeName GVAR(loadout_goggles) == "STRING" && {
+          GVAR(loadout_goggles) == "NotSet"
+        }) then {
+        GVAR(loadout_goggles) = goggles _unit;
+      } else {
+        if (typeName GVAR(loadout_goggles) == "STRING") then {
+          if (GVAR(loadout_goggles) == "") then {
+            GVAR(loadout_goggles) = goggles _unit;
+          }
+          else {
+            private _HeadgearTMP = [goggles _unit];
+            _HeadgearTMP pushBackUnique GVAR(loadout_goggles);
+            GVAR(loadout_goggles) = _HeadgearTMP;
+          };
+        } else {
+          private _HeadgearTMP = goggles _unit;
+          if (_HeadgearTMP != "") then {
+            GVAR(loadout_goggles) pushBackUnique _HeadgearTMP
+          };
+        };
+      };
+      systemChat format["[Set %1]: %2", _fncString, GVAR(loadout_goggles)];
+    };
+    case ("nods"): {
+      GVAR(loadout_nods) = hmd _unit;
+      systemChat format["[Set %1]: %2", _fncString, GVAR(loadout_nods)];
+    };
+    case ("reset"): {
+	GVAR(loadout_uniform) = "NotSet";
+	GVAR(loadout_vest) = "NotSet";
+	GVAR(loadout_backpack) = "NotSet";
+	GVAR(loadout_headgear) = "NotSet";
+	GVAR(loadout_rifle) = "NotSet";
+	GVAR(loadout_rifleMags) = "NotSet";
+	GVAR(loadout_rifleAttachments) = "NotSet";
+	GVAR(loadout_glrifle) = "NotSet";
+	GVAR(loadout_glRifleMags) = "NotSet";
+	GVAR(loadout_carbine) = "NotSet";
+	GVAR(loadout_carbineMags) = "NotSet";
+	GVAR(loadout_ar) = "NotSet";
+	GVAR(loadout_arMags) = "NotSet";
+	GVAR(loadout_arAttachments) = "NotSet";
+	GVAR(loadout_mmg) = "NotSet";
+	GVAR(loadout_mmgMags) = "NotSet";
+	GVAR(loadout_at) = "NotSet";
+	GVAR(loadout_atMags) = "NotSet";
+	GVAR(loadout_mat) = "NotSet";
+	GVAR(loadout_matMags) = "NotSet";
+	GVAR(loadout_goggles) = "NotSet";
+	/*
+	GVAR(loadout_hmg) = "NotSet";
+	GVAR(loadout_hmgMags) = "NotSet";
+	GVAR(loadout_hmgtrilo) = "NotSet";
+	GVAR(loadout_hmgtrihi) = "NotSet";
+	GVAR(loadout_hmgtrihi) = "NotSet";
+	GVAR(loadout_hat) = "NotSet";
+	GVAR(loadout_hatMags) = "NotSet";
+	GVAR(loadout_sam) = "NotSet";
+	GVAR(loadout_samMags) = "NotSet";
+	GVAR(loadout_sniper) = "NotSet";
+	GVAR(loadout_sniperMags) = "NotSet";
+	GVAR(loadout_spotter) = "NotSet";
+	GVAR(loadout_spotterMags) = "NotSet";
+	GVAR(loadout_smg) = "NotSet";
+	GVAR(loadout_smgMags) = "NotSet";
+	GVAR(loadout_pistol) = "NotSet";
+	GVAR(loadout_pistolMags) = "NotSet";
+	GVAR(loadout_mtrt) = "NotSet";
+	GVAR(loadout_mtrb) = "NotSet";
+	GVAR(loadout_crewh) = "NotSet";
+	GVAR(loadout_puniform) = "NotSet";
+	GVAR(loadout_pvest) = "NotSet";
+	GVAR(loadout_pbackpack) = "NotSet";
+	GVAR(loadout_pheadgear) = "NotSet";
+	GVAR(loadout_nods) = "NotSet";
+	*/
+    };
+    default {
+      ERROR_1("bad fnc [%1]", _fncString);
+    };
+  };
 {
     private _ctrlText = _x;
     private _output = "";

--- a/addons/arsenalExport/functions/fnc_export.sqf
+++ b/addons/arsenalExport/functions/fnc_export.sqf
@@ -35,43 +35,88 @@ private _fnc_getMags = {
     TRACE_4("getMags",_weapon,_mags,_wantedRounds,_return);
     _return
 };
+/*
+if (typeName GVAR(loadout_uniform) == "ARRAY") then {
+GVAR(loadout_uniform) = GVAR(loadout_uniform) joinString '","'
+};
+if (typeName GVAR(loadout_vest) == "ARRAY") then {
+GVAR(loadout_vest) = GVAR(loadout_vest) joinString '","'
+};
+if (typeName GVAR(loadout_backpack) == "ARRAY") then {
+GVAR(loadout_backpack) = GVAR(loadout_backpack) joinString '","'
+};
+if (typeName GVAR(loadout_headgear) == "ARRAY") then {
+GVAR(loadout_headgear) = GVAR(loadout_headgear) joinString '","'
+};
+if (typeName GVAR(loadout_crewh) == "ARRAY") then {
+GVAR(loadout_crewh) = GVAR(loadout_crewh) joinString '","'
+};
+if (typeName GVAR(loadout_puniform) == "ARRAY") then {
+GVAR(loadout_puniform) = GVAR(loadout_puniform) joinString '","'
+};
+if (typeName GVAR(loadout_pvest) == "ARRAY") then {
+GVAR(loadout_pvest) = GVAR(loadout_pvest) joinString '","'
+};
+if (typeName GVAR(loadout_pbackpack) == "ARRAY") then {
+GVAR(loadout_pbackpack) = GVAR(loadout_pbackpack) joinString '","'
+};
+if (typeName GVAR(loadout_pheadgear) == "ARRAY") then {
+GVAR(loadout_pheadgear) = GVAR(loadout_pheadgear) joinString '","'
+};
+if (typeName GVAR(loadout_goggles) == "ARRAY") then {
+GVAR(loadout_goggles) = GVAR(loadout_goggles) joinString '","'
+};
+*/
 
 private _lines = [];
+
 _lines pushBack format ["// Camo set"];
-_lines pushBack format ['#define CAMO_UNIFORM "%1"', GVAR(loadout_uniform)];
-_lines pushBack format ['#define CAMO_VEST "%1"', GVAR(loadout_vest)];
-_lines pushBack format ['#define CAMO_BACKPACK "%1"', GVAR(loadout_backpack)];
-_lines pushBack format ['#define CAMO_HEADGEAR "%1"', GVAR(loadout_headgear)];
+_lines pushBack format ['#define CAMO_UNIFORM %1', [GVAR(loadout_uniform)] call _fnc_formatList];
+_lines pushBack format ['#define CAMO_VEST %1', [GVAR(loadout_vest)] call _fnc_formatList];
+_lines pushBack format ['#define CAMO_BACKPACK %1', [GVAR(loadout_backpack)] call _fnc_formatList];
+_lines pushBack format ['#define CAMO_HEADGEAR %1', [GVAR(loadout_headgear)] call _fnc_formatList];
+
 
 _lines pushBack format ["// Rifle"];
 _lines pushBack format ['#define RIFLE "%1"', GVAR(loadout_rifle)];
+
 _lines pushBack format ['#define RIFLE_MAG %1', [GVAR(loadout_rifle), GVAR(loadout_rifleMags), 300] call _fnc_getMags];
 _lines pushBack format ['#define RIFLE_ATTACHMENTS %1', [GVAR(loadout_rifleAttachments)] call _fnc_formatList];
-_lines pushBack format ['#define AAR_ATTACHMENTS RIFLE_ATTACHMENTS'];
-_lines pushBack format ['#define ALT_OPTICS "optic_Aco","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad"'];
+_lines pushBack format ['#define AR_ATTACHMENTS RIFLE_ATTACHMENTS, %1', [GVAR(loadout_arAttachments)] call _fnc_formatList];
+_lines pushBack format ['#define ALT_OPTICS "optic_Aco","CUP_optic_CompM2_Black","CUP_optic_TrijiconRx01_black","CUP_optic_MRad",STANAG_OPTICS,WARSAW_OPTICS'];
 
 _lines pushBack format ["// GL Rifle"];
 _lines pushBack format ['#define GLRIFLE "%1"', GVAR(loadout_glrifle)];
 _lines pushBack format ['#define GLRIFLE_MAG %1', [GVAR(loadout_glrifle), GVAR(loadout_glRifleMags), 300] call _fnc_getMags];
 
+private _smoke = "";
+private _color = selectRandom ["B","G","O","P","Y"]; 
+switch (_color) do {
+case "B": {_smoke = "1Rnd_SmokeBlue_Grenade_shell:4"};
+case "G": {_smoke = "1Rnd_SmokeGreen_Grenade_shell:4"};
+case "O": {_smoke = "1Rnd_SmokeOrange_Grenade_shell:4"};
+case "P": {_smoke = "1Rnd_SmokePurple_Grenade_shell:4"};
+case "Y": {_smoke = "1Rnd_SmokeYellow_Grenade_shell:4"};
+};
+
 private _glMuzzle = (getArray (configFile >> "CfgWeapons" >> GVAR(loadout_glrifle) >> "muzzles")) param [1, "no2ndMuzzle"];
 private _glMags = [configFile >> "CfgWeapons" >> GVAR(loadout_glrifle) >> _glMuzzle] call CBA_fnc_compatibleMagazines;
 switch (true) do {
     case (({"1Rnd_Smoke_Grenade_shell" == _x} count _glMags) > 0):{
-        _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "1Rnd_Smoke_Grenade_shell:2","1Rnd_SmokeRed_Grenade_shell:2"'];
-        _lines pushBack format ['#define GLRIFLE_MAG_HE "1Rnd_HE_Grenade_shell:5"'];
         _lines pushBack format ['#define GLRIFLE_MAG_FLARE "UGL_FlareYellow_F:4"'];
+        _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "1Rnd_Smoke_Grenade_shell:6","1Rnd_SmokeRed_Grenade_shell:4","%1",GLRIFLE_MAG_FLARE', _smoke]; 
+        _lines pushBack format ['#define GLRIFLE_MAG_HE "1Rnd_HE_Grenade_shell:4"'];
     };
     case (({"rhs_GRD40_White" == _x} count _glMags) > 0):{
-        _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "rhs_GRD40_White:2","rhs_GRD40_Red:2"'];
-        _lines pushBack format ['#define GLRIFLE_MAG_HE "rhs_VOG25:5"'];
         _lines pushBack format ['#define GLRIFLE_MAG_FLARE "rhs_VG40OP_red:4"'];
+        _lines pushBack format ['#define GLRIFLE_MAG_SMOKE "rhs_GRD40_White:6","rhs_GRD40_Red:4","%1",GLRIFLE_MAG_FLARE', _smoke];
+        _lines pushBack format ['#define GLRIFLE_MAG_HE "rhs_VOG25:4"'];
     };
     default {
         _lines pushBack format ["// WARNING - Unknown GL Muzzle [%1->%2]", GVAR(loadout_glrifle), _glMuzzle];
+        _lines pushBack format ['#define GLRIFLE_MAG_FLARE ""'];
         _lines pushBack format ['#define GLRIFLE_MAG_SMOKE ""'];
         _lines pushBack format ['#define GLRIFLE_MAG_HE ""'];
-        _lines pushBack format ['#define GLRIFLE_MAG_FLARE ""'];
     };
 };
 
@@ -83,6 +128,7 @@ _lines pushBack format ["// AR"];
 _lines pushBack format ['#define AR "%1"', GVAR(loadout_ar)];
 _lines pushBack format ['#define AR_MAG %1', [GVAR(loadout_ar), GVAR(loadout_arMags), 500] call _fnc_getMags];
 
+
 _lines pushBack format ["// AT"];
 _lines pushBack format ['#define AT "%1"', GVAR(loadout_at)];
 _lines pushBack format ['#define AT_MAG %1', [GVAR(loadout_at), GVAR(loadout_atMags), -1] call _fnc_getMags];
@@ -90,12 +136,16 @@ _lines pushBack format ['#define AT_MAG %1', [GVAR(loadout_at), GVAR(loadout_atM
 _lines pushBack format ["// MMG"];
 _lines pushBack format ['#define MMG "%1"', GVAR(loadout_mmg)];
 _lines pushBack format ['#define MMG_MAG %1', [GVAR(loadout_mmg), GVAR(loadout_mmgMags), 500] call _fnc_getMags];
+_lines pushBack format ['#define MMG_ATT %1', [GVAR(loadout_mmgAttachments)] call _fnc_formatList];
 
 _lines pushBack format ["// MAT"];
 _lines pushBack format ['#define MAT "%1"', GVAR(loadout_mat)];
 _lines pushBack format ['#define MAT_MAG %1', [GVAR(loadout_mat), GVAR(loadout_matMags), -1] call _fnc_getMags];
 _lines pushBack format ['#define MAT_MAG2 %1', [GVAR(loadout_mat), GVAR(loadout_matMags), -1] call _fnc_getMags];
 _lines pushBack format ['#define MAT_OPTIC %1', [GVAR(loadout_matAttachments)] call _fnc_formatList];
+
+_lines pushBack format ["// Facewear"];
+_lines pushBack format ['#define GOG %1', [GVAR(loadout_goggles)] call _fnc_formatList];
 
 {
     "ace_clipboard" callExtension _x;

--- a/addons/assignGear/functions/fnc_assignGearMan.sqf
+++ b/addons/assignGear/functions/fnc_assignGearMan.sqf
@@ -24,12 +24,60 @@ private _faction = faction _unit;
 private _typeOf = typeOf _unit;
 private _unitClassname = [_typeOf] call FUNC(cleanPrefix);
 private _loadout = _unit getVariable ["F_Gear", _unitClassname]; //Check variable f_gear, otherwise default to typeof
+private _side = side _unit;
 private _path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+switch (_side) do{ 
+	case west:{
+		if (JKL_LoadoutWest isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutWest >> _loadout;
+		};
+	};   
+	case east:{ 
+		if (JKL_LoadoutEast isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutEast >> _loadout;
+		};
+	};   
+	case independent:{ 
+		if (JKL_LoadoutInd isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutInd >> _loadout;
+		}; 
+	};
+	default {_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;};
+};
 private _configFace = getArray (_path >> "face");
 private _face = if (_configFace isEqualTo[]) then { "" } else { selectRandom _configFace};
 
 if ((!isClass(_path)) && GVAR(useFallback)) then {
-    _path = missionConfigFile >> "CfgLoadouts" >> _faction >> "fallback";
+switch (_side) do{ 
+	case west:{
+		if (JKL_LoadoutWest isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> "fallback";
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutWest >> "fallback";
+		};
+	};   
+	case east:{ 
+		if (JKL_LoadoutEast isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> "fallback";
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutEast >> "fallback";
+		};
+	};   
+	case independent:{ 
+		if (JKL_LoadoutInd isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> "fallback";
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutInd >> "fallback";
+		}; 
+	};
+	default {_path = missionConfigFile >> "CfgLoadouts" >> _faction >> "fallback";};
+};
 };
 
 // Temp? BWC for older missions
@@ -120,7 +168,30 @@ if ((!isClass _path) && {(_typeOf select [0,7]) == "potato_"}) then {
             INFO_2("Convert msv %1:%2",_unitRole,_loadout);
         };
     };
-    _path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+switch (_side) do{ 
+	case west:{
+		if (JKL_LoadoutWest isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutWest >> _loadout;
+		};
+	};   
+	case east:{ 
+		if (JKL_LoadoutEast isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutEast >> _loadout;
+		};
+	};   
+	case independent:{ 
+		if (JKL_LoadoutInd isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutInd >> _loadout;
+		}; 
+	};
+	default {_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;};
+};
     if (!isClass(_path)) then { WARNING_3("No bwc class found %1=%2:%3", _typeOf,_faction,_loadout); };
 };
 

--- a/addons/assignGear/functions/fnc_assignGearVehicle.sqf
+++ b/addons/assignGear/functions/fnc_assignGearVehicle.sqf
@@ -47,14 +47,38 @@ if ((GVAR(setVehicleLoadouts) == -1) || {_loadout == "Empty"}) exitWith {
 };
 
 private _path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
-
+private _side = [_theVehicle, true] call BIS_fnc_objectSide;
+switch (west) do{ 
+	case west:{
+		if (JKL_LoadoutWest isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutWest >> _loadout;
+		};
+	};   
+	case (east):{ 
+		if (JKL_LoadoutEast isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutEast >> _loadout;
+		};
+	};   
+	case (independent):{ 
+		if (JKL_LoadoutInd isEqualTo "Default") then {
+			_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;
+		} else {
+			_path = configFile >> "CfgCMFLoadouts" >> JKL_LoadoutInd >> _loadout;
+		}; 
+	};
+	default {_path = missionConfigFile >> "CfgLoadouts" >> _faction >> _loadout;};
+};
 if (!isClass _path) then {
     //No CfgLoadouts for exact loadout, try default
     private _vehConfigSide = [_theVehicle, true] call BIS_fnc_objectSide;
     private _vehConfigFactions = switch (_vehConfigSide) do {
-        case (west): { ["blu_f", "potato_w"] };
-        case (east): { ["opf_f", "potato_e", "potato_msv"] }; // potato_msv is depcrecated but kept for BWC for now
-        case (independent): { ["ind_f", "potato_i"] };
+        case (west): { ["blu_f", "potato_w", JKL_LoadoutWest] };
+        case (east): { ["opf_f", "potato_e", "potato_msv", JKL_LoadoutEast] }; // potato_msv is depcrecated but kept for BWC for now
+        case (independent): { ["ind_f", "potato_i", JKL_LoadoutInd] };
         default { ["civ_f"] };
     };
 
@@ -63,7 +87,30 @@ if (!isClass _path) then {
         private _loadoutToCheck = _x;
 
         {
-            _path = missionConfigFile >> "CfgLoadouts" >> _x >> _loadoutToCheck;
+		switch (_side) do{ 
+			case (west):{
+				if (JKL_LoadoutWest isEqualTo "Default") then {
+					_path = missionConfigFile >> "CfgLoadouts" >> _x >> _loadoutToCheck;
+				} else {
+					_path = configFile >> "CfgCMFLoadouts" >> _x >> _loadoutToCheck;
+				};
+			};   
+			case (east):{ 
+				if (JKL_LoadoutEast isEqualTo "Default") then {
+					_path = missionConfigFile >> "CfgLoadouts" >> _x >> _loadoutToCheck;
+				} else {
+					_path = configFile >> "CfgCMFLoadouts" >> _x >> _loadoutToCheck;
+				};
+			};   
+			case (independent):{ 
+				if (JKL_LoadoutInd isEqualTo "Default") then {
+					_path = missionConfigFile >> "CfgLoadouts" >> _x >> _loadoutToCheck;
+				} else {
+					_path = configFile >> "CfgCMFLoadouts" >> _x >> _loadoutToCheck;
+				}; 
+			};
+			default {_path = missionConfigFile >> "CfgLoadouts" >> _x >> _loadoutToCheck};
+			};
             if (isClass _path) exitWith { _break = true; };
         } forEach _vehConfigFactions;
 

--- a/addons/missionTesting/CfgEden.hpp
+++ b/addons/missionTesting/CfgEden.hpp
@@ -66,6 +66,10 @@ class Cfg3DEN {
                                     name = "TVT";
                                     value = 2;
                                 };
+                                class ZBM {
+                                    name = "ZBM";
+                                    value = 3;
+                                };
                             };
 						};
 						class GVAR(missionVersion) {


### PR DESCRIPTION
Arsenal Export
-Added SET GOG to encourage mission makers to add facewear to their gearscripts
-SET UNIFORM and SET GOG now make an array when selecting and setting multiple uniforms
-GL Smoke automatically exports with 6 White, 4 Red, and 4 colored smoke of a Random Color

CMF
-Premade, and Preapproved gearscripts are now in the modpack
 -About 20 have been added with more to come, Let JKL Know if there are any ERROES with them
-New Gear Select Ace Interact for Leadership during safestart
 -Allows the Highest Ranking leader to select the gearscript for the whole platoon for ZBM Missions
-New Zeus Select Gear Module in the Module Menu
 -Allows Zeus to set the gear of any side, during any mission
-Both of these also update Mini Arsenal with the new Gear

Potato Mission Settings
-New Mission Type "ZBM" enables aforementioned gear select for leadership